### PR TITLE
Bugfix RFID2 -Enter key on keyboard [Double Click]

### DIFF
--- a/bruce.ino
+++ b/bruce.ino
@@ -2924,11 +2924,13 @@ void rfid_loop()
       case read_mode:
         currentState = write_mode;
         displayWriteMode();
+        delay(300);
         break;
       case write_mode:
         currentState = read_mode;
         displayReadMode();
         readUID = false;
+        delay(300);
         break;
     }
   }


### PR DESCRIPTION
I noticed that when pressing the ENTER key on the keyboard, RFID2 was performing a "double click", making it difficult to reach the writing screen on a new card or RFID tag.

A delay was added to the button to avoid the aforementioned bug